### PR TITLE
feat: logout

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -1,38 +1,35 @@
 <template>
   <div style="z-index:9">
+    <v-dialog v-model="logoutDialog" persistent max-width="290">
+      <v-card>
+        <v-card-title class="headline">确认登出？</v-card-title>
+        <v-card-text>我们会保存您所有的操作。</v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="green darken-1" flat @click="logoutDialog = false">取消</v-btn>
+          <v-btn color="error darken-1" flat @click="handleLoginStatus">确认</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-toolbar color="primary" height="80">
-      <v-toolbar-title class="toolBar-title" @click="jump('homepage')">
-        计算机基础知识竞赛
-      </v-toolbar-title>
+      <v-toolbar-title class="toolBar-title" @click="jump('homepage')">计算机基础知识竞赛</v-toolbar-title>
       <v-spacer></v-spacer>
       <v-badge color="error" overlap>
         <template v-if="noticeCount" v-slot:badge>{{noticeCount}}</template>
-        <v-btn flat type @click="jump('notice')">
-          <div class="toolBar-btn" >公告</div>
+        <v-btn flat type="" @click="jump('notice')">
+          <div class="toolBar-btn">公告</div>
         </v-btn>
       </v-badge>
-      <v-btn flat @click="jump('login')">
+      <v-btn flat @click="handleLoginStatus" v-if="!loginStatus">
         <div class="toolBar-btn">登录</div>
       </v-btn>
-    </v-toolbar>
-    <v-snackbar
-      v-model="showSnackbar"
-      :timeout="4000"
-      bottom=""
-      color="#0D47A1"
-      style="bottom: 10px"
-    >
-      <div @click="handleClickSnackbar" style="cursor: pointer">
-        新公告
-      </div>
-      <v-btn
-        flat
-        dark
-        text
-        @click="showSnackbar = false"
-      >
-        Close
+      <v-btn flat v-else @click.stop="logoutDialog = true">
+        <div class="toolBar-btn">注销</div>
       </v-btn>
+    </v-toolbar>
+    <v-snackbar v-model="showSnackbar" :timeout="4000" bottom color="#0D47A1" style="bottom: 10px">
+      <div @click="handleClickSnackbar" style="cursor: pointer">新公告</div>
+      <v-btn flat dark text="" @click="showSnackbar = false">Close</v-btn>
     </v-snackbar>
   </div>
 </template>
@@ -44,11 +41,22 @@ export default {
   data() {
     return {
       showSnackbar: false,
+      logoutDialog: false,
+      timer: null,
     };
   },
   computed: {
     noticeCount() {
       return this.$store.getters.unreadNoticeCount;
+    },
+    loginStatus() {
+      return this.$store.state.loginStatus;
+    },
+  },
+  watch: {
+    loginStatus: {
+      handler: 'handleInterval',
+      immediate: true,
     },
   },
   methods: {
@@ -59,8 +67,27 @@ export default {
       this.showSnackbar = false;
       this.jump('notice');
     },
+    handleLoginStatus() {
+      if (this.loginStatus) {
+        this.logoutDialog = false;
+        localStorage.removeItem('fresh_cup_token');
+        this.$store.commit('handleLoginStatus', false);
+        this.$store.dispatch('reset');
+      }
+      this.jump('login');
+    },
+    handleInterval() {
+      if (this.loginStatus) {
+        this.timer = setInterval(() => {
+          this.$store.dispatch('update');
+        }, 10000);
+      } else {
+        // 登录状态为false时清理定时
+        clearInterval(this.timer);
+      }
+    },
   },
-  async mounted() {
+  mounted() {
     if (!localStorage.getItem('fresh_cup_token')) {
       this.$router.push({ name: 'login' });
     }
@@ -72,7 +99,7 @@ export default {
 .toolBar-title
   color white
   margin-left 20px !important
-  cursor: pointer
+  cursor pointer
   user-select none
 .toolBar-btn
   color white

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -67,14 +67,17 @@ export default {
       this.showSnackbar = false;
       this.jump('notice');
     },
-    handleLoginStatus() {
+    async handleLoginStatus() {
       if (this.loginStatus) {
         this.logoutDialog = false;
         localStorage.removeItem('fresh_cup_token');
         this.$store.commit('handleLoginStatus', false);
-        this.$store.dispatch('reset');
+        await this.$store.dispatch('reset').then(() => {
+          this.jump('login');
+        });
+      } else {
+        this.jump('login');
       }
-      this.jump('login');
     },
     handleInterval() {
       if (this.loginStatus) {

--- a/src/store.js
+++ b/src/store.js
@@ -18,6 +18,29 @@ const injectAnswer = (questionArray, submittedArray) => {
   });
 };
 
+const INIT_STATE = {
+  noticeArray: [],
+  questionArray: [],
+  due: {
+    start: 0,
+    end: 0,
+  },
+  readNoticeArray: [],
+  hash: {
+    problemsMd5: '',
+    noticesMd5: '',
+  },
+  name: '',
+  userinfo: {
+    id: 0,
+    username: '',
+    email: '',
+    isAdmin: 0,
+  },
+  submittedArray: [],
+  loginStatus: false,
+};
+
 const state = {
   noticeArray: [],
   questionArray: [],
@@ -38,6 +61,7 @@ const state = {
     isAdmin: 0,
   },
   submittedArray: [],
+  loginStatus: !!localStorage.getItem('fresh_cup_token'),
 };
 
 const getters = {
@@ -69,6 +93,12 @@ const mutations = {
   },
   handleSubmittedInit(State, newSubmitted) {
     State.submittedArray = newSubmitted;
+  },
+  handleResetState(State, initState) {
+    Object.assign(state, initState);
+  },
+  handleLoginStatus(State, newStatus) {
+    State.loginStatus = newStatus;
   },
 };
 
@@ -111,6 +141,9 @@ const actions = {
     const newQuestionArray = await injectAnswer(tempQuestionArray, submitted);
     await commit('injectCommitted', newQuestionArray);
     await commit('handleSubmittedInit', submitted);
+  },
+  async reset({ commit }) {
+    await commit('handleResetState', INIT_STATE);
   },
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -95,7 +95,7 @@ const mutations = {
     State.submittedArray = newSubmitted;
   },
   handleResetState(State, initState) {
-    Object.assign(state, initState);
+    Object.assign(State, initState);
   },
   handleLoginStatus(State, newStatus) {
     State.loginStatus = newStatus;

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1,37 +1,54 @@
 <template>
-  <v-card
-    max-width="500"
-    class="mx-auto"
-  >
-    <v-card-title class="card_title">致2019年新生：</v-card-title>
-    <v-card-text>欢迎参加南京邮电大学校科协新生杯
-                <br>点击确定报名参加本次比赛</v-card-text>
-    <v-card-actions>
-      <v-spacer></v-spacer>
+  <div class="homepage-container">
+    <v-card width="500" class="mx-auto">
+      <v-card-title class="card_title">致2019年新生：</v-card-title>
+      <v-card-text>欢迎参加南京邮电大学校科协新生杯
+        <br>点击确定报名参加本次比赛
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
         <router-link to="Login">
-               <v-btn color="primary">确认</v-btn>
+          <v-btn color="primary">确认</v-btn>
         </router-link>
-    </v-card-actions>
-  </v-card>
+      </v-card-actions>
+    </v-card>
+  </div>
 </template>
 
 <script>
-
+export default {
+  mounted() {
+    if (localStorage.getItem('fresh_cup_token')) {
+      const { isAdmin } = this.$store.state.userinfo;
+      if (isAdmin) {
+        this.$router.push({ name: 'admin' });
+      } else {
+        this.$router.push({ name: 'answer' });
+      }
+    }
+  },
+};
 </script>
 
 <style scoped>
-.mx-auto{
-  margin:150px auto;
-  box-shadow:0 0 8px rgb(131, 132, 133);
+.homepage-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 80px - 36px)
 }
-.card_title{
-    background-color: #1976d2;
-    color:#fff;
-    font-size:20px;
-  }
-.v-card__text{
-    padding:20px;
-    line-height:35px;
-    font-size:18px;
-  }
+.mx-auto {
+  margin: 150px auto;
+  box-shadow: 0 0 8px rgb(131, 132, 133);
+}
+.card_title {
+  background-color: #1976d2;
+  color: #fff;
+  font-size: 20px;
+}
+.v-card__text {
+  padding: 20px;
+  line-height: 35px;
+  font-size: 18px;
+}
 </style>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -6,7 +6,7 @@
       :right="true"
       :top="true"
       :timeout="3000"
-    >登录失败，请检查学号或密码是否正确</v-snackbar>
+    >登录失败，请检查用户名/邮箱或密码是否正确</v-snackbar>
     <v-container fluid fill-height>
       <v-layout align-center justify-center>
         <v-flex xs12 sm8 md4>
@@ -18,7 +18,7 @@
             <v-card-text>
               <v-form>
                 <v-text-field
-                  label="学号"
+                  label="用户名/邮箱"
                   :clearable="true"
                   v-model="studentID"
                   name="login"
@@ -59,23 +59,19 @@ export default {
   }),
   methods: {
     async handleLogin() {
-      /** 登录成功 => */
-      // /** 登录失败 => */ this.loginError = true;
       this.btnLoading = true;
       const { ret } = await login(this.studentID, this.password);
       if (ret === 200) {
         const {
-          data: {
-            is_admin: isAdmin, ...rest
-          },
+          data: { is_admin: isAdmin, ...rest },
         } = await userinfo();
         this.$store.commit('handleUserinfo', {
-          ...rest, isAdmin,
+          ...rest,
+          isAdmin,
         });
-        setInterval(() => {
-          this.$store.dispatch('update');
-        }, 10000);
-        await this.$store.dispatch('init');
+        await this.$store.dispatch('init').then(() => {
+          this.$store.commit('handleLoginStatus', true);
+        });
         this.btnLoading = false;
         if (isAdmin) {
           this.$router.push({ name: 'admin' });
@@ -92,5 +88,5 @@ export default {
 
 <style lang="stylus">
 .login-container
-  height 88vh
+  height calc(100vh - 80px - 36px)
 </style>


### PR DESCRIPTION
1. 添加了 _注销_ 按钮；
2. `store.js` 中添加了清空 _state_ 的 _mutation_；
3. 将 `Login.vue` 中的设置轮询移到了 `ToolBa.vuer`，并根据登录状态判断开启或销毁；
4. 添加了登录后的主页跳转，现在登录后点击左上角会根据身份跳转到指定页面；
5. 目前写的 `$store.state.loginStatus` 可能会有问题，以及登入后，如果有个请求在 _pending_ ，在此时 登出这个请求会继续下去，导致清空的 `$store.state` 又被重新赋值，这些待解决